### PR TITLE
Accounts Admin: Fix tinymce mce_attrs

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -47,7 +47,7 @@ class TinyMCEFlatPageAdmin(FlatPageAdmin):
         if db_field.name == 'content':
             return forms.CharField(widget=TinyMCE(
                 attrs={'cols': 80, 'rows': 30},
-                mce_attrs={'external_link_list_url': reverse('tinymce.views.flatpages_link_list')},
+                mce_attrs={'external_link_list_url': reverse('tinymce-linklist')},
             ))
         return super(TinyMCEFlatPageAdmin, self).formfield_for_dbfield(db_field, **kwargs)
 


### PR DESCRIPTION
For me, editing django flatpages gave a HTTP 500.
It seems like tinymce.views.flatpages_link_list no longer exists.

The commit that changed the usage doc (https://github.com/jazzband/django-tinymce/blob/ff015bef65f32170ef116548861e540279cae227/docs/usage.rst#the-flatpages_link_list-view) is the following: https://github.com/jazzband/django-tinymce/commit/be6a9595853071ece52b8981af2c079bec3d8b03

So it seems like this new name is to fix a Django 1.10 compatibility issue. This fixed my HTTP 500.